### PR TITLE
FIX: Chord parsing causes System.NullReferenceException

### DIFF
--- a/src/NFugue/Integration/MusicXml/MusicXmlParser.cs
+++ b/src/NFugue/Integration/MusicXml/MusicXmlParser.cs
@@ -364,7 +364,7 @@ namespace NFugue.Integration.MusicXml
 
         private void ParseGuitarChord(XElement harmony)
         {
-            StringBuilder chordString = new StringBuilder(" ");
+            StringBuilder chordString = new StringBuilder("");
             AppendToChord(chordString, harmony, "root");
             var chordKind = harmony.Element("kind");
             if (chordKind != null)


### PR DESCRIPTION
Parsing [a score which contains chords](https://musescore.com/user/9847751/scores/4902520) will throw System.NullReferenceException at [Chord.cs#L82](https://github.com/Sh1noka/NFugue/blob/chord-parsing-bug/src/NFugue/Theory/Chord.cs#L82).

There is an unneeded space at the beginning of [chordString](https://github.com/mchudy/NFugue/blob/master/src/NFugue/Integration/MusicXml/MusicXmlParser.cs#L367). This will cause [parseNoteElement(index = 0)](https://github.com/Sh1noka/NFugue/blob/chord-parsing-bug/src/NFugue/Staccato/Subparsers/NoteSubparser/NoteSubparser.cs#L64) fail.